### PR TITLE
Removed SecureRadom dep

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -46,7 +46,6 @@ defmodule Hades.Mixfile do
       {:stream_data, "~> 0.1", only: :test},
       {:comeonin, "~> 4.0"},
       {:bcrypt_elixir, "~> 0.12.0"},
-      {:secure_random, "~> 0.5"},
       {:guardian, "~> 1.0"}
     ]
   end


### PR DESCRIPTION
I don't think we need this dependency anymore since it was only being used to generate a random hash to the `auth_token` field on users which was already removed and if we want to go back to this approach again we can use guardian or bcrypt to generate random token.