### PR TITLE
Minor improvements and code clean up

### DIFF
--- a/lib/hades/accounts/auth.ex
+++ b/lib/hades/accounts/auth.ex
@@ -27,19 +27,4 @@ defmodule Hades.Accounts.Auth do
         {:error, :not_found}
     end
   end
-
-  def reset_password(user, attrs) do
-    changeset = User.changeset_update_password(user, attrs)
-
-    if checkpw(attrs[:old_password], user.password_hash) do
-      case Repo.update(changeset) do
-        {:ok, user} ->
-          {:ok, user}
-        {:error, changeset} ->
-          {:error, changeset}
-      end
-    else
-      {:error, :invalid_password}
-    end
-  end
 end

--- a/lib/hades/accounts/users.ex
+++ b/lib/hades/accounts/users.ex
@@ -1,4 +1,6 @@
 defmodule Hades.Accounts.Users do
+  import Comeonin.Bcrypt, only: [checkpw: 2]
+
   alias Hades.Repo
   alias Hades.Accounts.User
 
@@ -15,6 +17,21 @@ defmodule Hades.Accounts.Users do
     user
     |> User.changeset_update_user(attrs)
     |> Repo.update
+  end
+
+  def update_password(user, attrs) do
+    changeset = User.changeset_update_password(user, attrs)
+
+    if checkpw(attrs[:old_password], user.password_hash) do
+      case Repo.update(changeset) do
+        {:ok, user} ->
+          {:ok, user}
+        {:error, changeset} ->
+          {:error, changeset}
+      end
+    else
+      {:error, :invalid_password}
+    end
   end
 
   def delete_user(user), do: Repo.delete(user)

--- a/test/hades/accounts/auth_test.exs
+++ b/test/hades/accounts/auth_test.exs
@@ -75,30 +75,4 @@ defmodule Hades.Accounts.AuthTest do
       assert {:error, :not_found} = Auth.sign_in(FakeData.email, "S0m3p4ssW0rd")
     end
   end
-
-  describe "reset_password/2" do
-    test "resets password with valid data", %{user: user} do
-      reset_password_valid_attrs =
-        %{
-          old_password: user.password,
-          password: "n3wP455w0rd",
-          password_confirmation: "n3wP455w0rd"
-        }
-      assert {:ok, %User{}} = Auth.reset_password(user, reset_password_valid_attrs)
-    end
-
-    test "returns error when passwords don't match", %{user: user} do
-      reset_password_invalid_attrs =
-        %{
-          old_password: user.password,
-          password: "n3wP455w0rd",
-          password_confirmation: "d0ntm4tch"
-        }
-      assert {:error, %Ecto.Changeset{}} = Auth.reset_password(user, reset_password_invalid_attrs)
-    end
-
-    test "does not reset password when new password data is not provided", %{user2: user} do
-      assert {:error, %Ecto.Changeset{}} = Auth.reset_password(user, %{old_password: user.password})
-    end
-  end
 end

--- a/test/hades/accounts/users_test.exs
+++ b/test/hades/accounts/users_test.exs
@@ -12,6 +12,11 @@ defmodule Hades.Accounts.UsersTest do
     is_admin: FakeData.boolean,
   }
 
+  @update_password_valid_attrs %{
+    password: "n3wP455w0rd",
+    password_confirmation: "n3wP455w0rd"
+  }
+
   setup do
     user = insert(:user)
     %{user: user}
@@ -29,6 +34,26 @@ defmodule Hades.Accounts.UsersTest do
       assert user.email == @valid_attrs.email
       assert user.name == @valid_attrs.name
       assert user.is_admin == @valid_attrs.is_admin
+    end
+  end
+
+  describe "update_password/2" do
+    test "updates password with valid data", %{user: user} do
+      assert {:ok, %User{}} = Users.update_password(user, Map.merge(@update_password_valid_attrs, %{old_password: user.password}))
+    end
+
+    test "returns error when passwords don't match", %{user: user} do
+      update_password_invalid_attrs =
+        %{
+          old_password: user.password,
+          password: "n3wP455w0rd",
+          password_confirmation: "d0ntm4tch"
+        }
+      assert {:error, %Ecto.Changeset{}} = Users.update_password(user, update_password_invalid_attrs)
+    end
+
+    test "does not update password when new password data is not provided", %{user: user} do
+      assert {:error, %Ecto.Changeset{}} = Users.update_password(user, %{old_password: user.password})
     end
   end
 


### PR DESCRIPTION
- Renames the `reset_password` function to `update_password` because this is not the one which should recover the user's lost pass.
- Moved `update_password` to users helper since this is mostly a user stuff than authentication. 